### PR TITLE
feat: add user journeys for basic stepping with source maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,27 @@ TARGETS= \
 	$(DISTDIR)/fibonacci.html \
 	$(DISTDIR)/hello.html \
 	$(DISTDIR)/hello-threads.html \
-	$(DISTDIR)/index.html
+	$(DISTDIR)/index.html \
+	$(DISTDIR)/stepping-with-state.c \
+	$(DISTDIR)/stepping-with-state.js \
+	$(DISTDIR)/stepping-with-state-sourcemaps.html \
+	$(DISTDIR)/stepping-with-state-and-threads.c \
+	$(DISTDIR)/stepping-with-state-and-threads.js \
+	$(DISTDIR)/stepping-with-state-and-threads-sourcemaps.html
 
 all: $(DISTDIR) $(TARGETS)
 
 $(DISTDIR):
 	mkdir -p $(DISTDIR)
 
-$(DISTDIR)/index.html: index.html
+$(DISTDIR)/%.html: %.html
 	cp $< $@
 
-$(DISTDIR)/crbug-837572.c: crbug-837572.c
+$(DISTDIR)/%.c: %.c
 	cp $< $@
 
 $(DISTDIR)/crbug-837572.html: crbug-837572.c
 	$(EMCC) -g4 --source-map-base $(SOURCE_MAP_BASE) -o $@ ./$<
-
-$(DISTDIR)/crbug-887384.c: crbug-887384.c
-	cp $< $@
 
 $(DISTDIR)/crbug-887384.html: crbug-887384.c
 	$(EMCC) -g4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=2 --source-map-base $(SOURCE_MAP_BASE) -o $@ ./$<
@@ -41,6 +44,12 @@ $(DISTDIR)/hello.html: hello.c
 
 $(DISTDIR)/hello-threads.html: hello-threads.c
 	$(EMCC) -g -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=2 -o $@ $<
+
+$(DISTDIR)/stepping-with-state.js: stepping-with-state.c
+	$(EMCC) -g4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=1 --source-map-base $(SOURCE_MAP_BASE) -o $@ ./$<
+
+$(DISTDIR)/stepping-with-state-and-threads.js: stepping-with-state-and-threads.c
+	$(EMCC) -g4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=1 --source-map-base $(SOURCE_MAP_BASE) -o $@ ./$<
 
 start: all
 	python3 -m http.server --directory $(DISTDIR) 4000

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
       <li><a href="fibonacci.html">Basic fibonacci example</a></li>
       <li><a href="hello.html">Basic hello world example</a></li>
       <li><a href="hello-threads.html">Basic hello threads example</a></li>
+      <li><a href="stepping-with-state-sourcemaps.html">Basic stepping example with source maps</a></li>
+      <li><a href="stepping-with-state-and-threads-sourcemaps.html">Basic stepping with source maps and threads</a></li>
     </ol>
   </body>
 </html>

--- a/stepping-with-state-and-threads-sourcemaps.html
+++ b/stepping-with-state-and-threads-sourcemaps.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Step with state</title>
+    <script src="stepping-with-state-and-threads.js"></script>
+  </head>
+  <body>
+    <h1>Stepping in original source with state and threads</h1>
+    <p>
+      This tests that we can successfully complete a debugging session with source maps, including
+      setting breakpoints, deleting breakpoints, and stepping.
+    </p>
+
+    <h2>Steps</h2>
+
+    <p>
+      <li>Inspect main thread:</li>
+      <ol>        
+        <li>Open DevTools</li>
+        <li>Open stepping-with-state-and-threads.c</li>
+        <li>Set a breakpoint at function <code>main</code> on line <code>args *thread_args = (args*) malloc(sizeof(args));
+        </code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit set breakpoint</li>
+        <li>Step a few times until the next line is hit and inspect wasm variables</li>
+        <li>Remove breakpoint</li>
+        <li>Set a breakpoint at function <code>addConstant</code> on line <code>for (int i = 0; i < length; ++i) {</code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit the new breakpoint</li>
+        <li>Step a few times and inspect the wasm variables in the scope view</li>
+        <li>Resume</li>
+      </ol>
+      <li>Inspect worker thread:</li>
+      <ol>
+        <li>Set a breakpoint at function <code>threadEntryPoint</code> on line <code>args *arguments = (args*) input;</code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit set breakpoint</li>
+        <li>Step a few times until the next line is hit and inspect wasm variables</li>
+        <li>Remove breakpoint</li>
+        <li>Set a breakpoint at function <code>multiplyByConstant</code> on line <code>for (int i = 0; i < length; ++i) {</code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit the new breakpoint</li>
+        <li>Step a few times until the next line is hit and inspect the wasm variables in the scope view</li>
+        <li>Remove breakpoint</li> 
+        <li>Resume</li>  
+      </ol>   
+    </p>
+
+  </body>
+</html>

--- a/stepping-with-state-and-threads.c
+++ b/stepping-with-state-and-threads.c
@@ -1,0 +1,71 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct args_ty {
+    int *array;
+    int length;
+    int constant;
+} args;
+
+/* multiplies each element by a constant */
+void multiplyByConstant(int *array, int length, int constant) {
+  for (int i = 0; i < length; ++i) {
+      array[i] *= constant;
+  }
+}
+
+/* adds a constant to each element */
+void addConstant(int *array, int length, int constant) {
+  for (int i = 0; i < length; ++i) {
+    array[i] += constant;
+  }  
+}
+
+/* entry point for thread */
+void *threadEntryPoint(void *input) {
+  args *arguments = (args*) input;
+  multiplyByConstant(arguments->array, arguments->length, arguments->constant);
+  return NULL;
+}
+
+int main() {
+  int n = 10;
+  int x[n], y[n];
+
+  /* initialize x and y */
+  for (int i = 0; i < n; ++i) {
+    x[i] = i;
+    y[i] = n-i-1;
+  }
+
+  /* this variable is our reference to the thread */
+  pthread_t thread;
+
+  /* intialize the argument to the thread */
+  args *thread_args = (args*) malloc(sizeof(args));
+  thread_args->array = x;
+  thread_args->length = n;
+  thread_args->constant = 5;
+
+  /* create a second thread which executes threadEntryPoint */
+  if(pthread_create(&thread, NULL, threadEntryPoint, (void*) thread_args)) {
+    fprintf(stderr, "Error creating thread\n");
+    return 1;
+  }
+
+  /* add 5 to each element in y */
+  addConstant(y, n, 5);
+
+  /* wait for the second thread to finish */
+  if(pthread_join(thread, NULL)) {
+    fprintf(stderr, "Error joining thread\n");
+    return 2;
+  }
+
+  /* output x and y */
+  for (int i = 0; i < n; ++i) {
+      printf("x[%d] = %d, y[%d] = %d\n", i, x[i], i, y[i]);
+  }
+  return 0;
+}

--- a/stepping-with-state-sourcemaps.html
+++ b/stepping-with-state-sourcemaps.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Step with state</title>
+    <script src="stepping-with-state.js"></script>
+  </head>
+  <body>
+    <h1>Stepping in original source with state</h1>
+    <p>
+      This tests that we can successfully complete a debugging session with source maps, including
+      setting breakpoints, deleting breakpoints, and stepping.
+    </p>
+
+    <h2>Steps</h2>
+
+    <p>
+      <ol>
+        <li>Open DevTools</li>
+        <li>Open stepping-with-state.c</li>
+        <li>Set a breakpoint at function <code>main</code> on line <code>int n = 10</code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit set breakpoint</li>
+        <li>Step a few times until the next line is hit</li>
+        <li>Remove breakpoint</li>
+        <li>Set a breakpoint at function <code>multiplyByConstant</code> on line <code>for (int i = 0; i < length; ++i) {</code></li>
+        <li>Reload</li>
+        <li>Breakpoint should hit the new breakpoint</li>
+        <li>Step a few times and inspect the wasm variables in the scope view</li>
+        <li>Remove breakpoint</li> 
+        <li>Resume</li>
+      </ol>
+    </p>
+  </body>
+</html>

--- a/stepping-with-state.c
+++ b/stepping-with-state.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+/* multiplies each element by a constant */
+void multiplyByConstant(int *array, int length, int constant) {
+  for (int i = 0; i < length; ++i) {
+      array[i] *= constant;
+  }
+}
+
+int main() {
+  int n = 10;
+  int x[n];
+
+  /* initialize x */
+  for (int i = 0; i < n; ++i) {
+    x[i] = i;
+  }
+
+  /* multiply each element by 5 */
+  multiplyByConstant(x, n, 5);
+
+  /* output x */
+  for (int i = 0; i < n; ++i) {
+      printf("x[%d] = %d\n", i, x[i]);
+  }
+  return 0;
+}


### PR DESCRIPTION
This adds two examples for the user stories 2. and 4. referenced in [the wasm user stories design doc](https://docs.google.com/document/d/1XBlUbyYfPsn1OuCpq2F-O7E3zvsfa94ZFsiIcnq2w7I/edit?usp=sharing):

- stepping with state in original source
- stepping with state and threads in original source