### PR TITLE
Edit examples to simplify testing pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ TARGETS= \
 	$(DISTDIR)/lmi.html \
 	$(DISTDIR)/lmi-primitives.cc \
 	$(DISTDIR)/lmi-primitives.html \
-	$(DISTDIR)/lmi-structs.cc \
-	$(DISTDIR)/lmi-structs.html \
+	$(DISTDIR)/lmi-structs-classes.cc \
+	$(DISTDIR)/lmi-structs-classes.html \
 	$(DISTDIR)/mandelbrot.cc \
 	$(DISTDIR)/mandelbrot.html \
 	$(DISTDIR)/simd.c \
@@ -184,7 +184,7 @@ $(DISTDIR)/lmi.html: lmi.cc
 $(DISTDIR)/lmi-primitives.html: lmi-primitives.cc
 	$(EMXX) -g -O0 -fdebug-compilation-dir=. -o $@ ./$<
 
-$(DISTDIR)/lmi-structs.html: lmi-structs.cc
+$(DISTDIR)/lmi-structs-classes.html: lmi-structs-classes.cc
 	$(EMXX) -g -O0 -fdebug-compilation-dir=. -o $@ ./$<
 
 $(DISTDIR)/mandelbrot.html: mandelbrot.cc

--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
       <li><a href="inlining-dwarf.html">Trivial inlining example (DWARF)</a></li>
       <li><a href="inlining-sourcemaps.html">Trivial inlining example (sourcemaps)</a></li>
       <li><a href="lmi.html">Opening linear memory inspector example (DWARF)</a></li>
-      <li><a href="lmi-primitives.html">Opening linear memory inspector example with primitives (DWARF)</a></li>
-      <li><a href="lmi-structs.html">Opening linear memory inspector example with structs (DWARF)</a></li>
+      <li><a href="lmi-primitives.html">Opening linear memory inspector with primitives (DWARF)</a></li>
+      <li><a href="lmi-structs-classes.html">Opening linear memory inspector with structs and classes (DWARF)</a></li>
       <li><a href="stepping-with-state-sourcemaps.html">Basic stepping example with source maps</a></li>
       <li><a href="stepping-with-state-and-threads-sourcemaps.html">Basic stepping with source maps and threads</a></li>
       <li><a href="stepping-with-state-and-threads-sourcemaps-proxytopthread.html">Basic stepping with source maps, threads and proxy-to-pthread</a></li>

--- a/lmi-primitives.cc
+++ b/lmi-primitives.cc
@@ -16,10 +16,10 @@ int main() {
   float f = 42.5;
   double d = 123.456;
   wchar_t w = L'A';
-  
   // Added for testing double pointers.
   double *ptr = &d;
   double **dblptr = &ptr;
-  
+
   usePrimitives(i, c, b, f, d, w);
+  std::cout << "ptr: " << ptr << ", dblptr: " << dblptr << "\n";
 }

--- a/lmi-primitives.cc
+++ b/lmi-primitives.cc
@@ -17,5 +17,9 @@ int main() {
   double d = 123.456;
   wchar_t w = L'A';
   
+  // Added for testing double pointers.
+  double *ptr = &d;
+  double **dblptr = &ptr;
+  
   usePrimitives(i, c, b, f, d, w);
 }

--- a/lmi-structs-classes.cc
+++ b/lmi-structs-classes.cc
@@ -9,14 +9,14 @@ struct movie {
 
 class MovieReview {
   public:
-    movie mov;
+    movie *mov;
     std::string review;
     int rating;
     void printMovieRating() {
-      std::cout << this->mov.title << ": " << this->rating << "/5" << "\n";
+      std::cout << this->mov->title << ": " << this->rating << "/5" << "\n";
     }
     
-    MovieReview(movie m, std::string review, int rating) {
+    MovieReview(movie *m, std::string review, int rating) {
       this->mov = m;
       this->review = review;
       this->rating = rating;
@@ -29,15 +29,17 @@ int main() {
   stargate.year_released = 2008;
   stargate.budget = 7000000;
 
-  MovieReview stargateReview(stargate, "The best thing since sliced bread.", 5);
+  MovieReview stargateReview(&stargate, "The best thing since sliced bread.", 5);
   stargateReview.printMovieRating();
   
   // Added for testing double pointers.
-  movie *ptr = &stargate;
-  movie **dblptr = &ptr;
-  MovieReview *reviewptr = &stargateReview;
-  MovieReview **reviewdblptr = &reviewptr;
-
+  {
+    movie *ptr = &stargate;
+    movie **dblptr = &ptr;
+    MovieReview *reviewptr = &stargateReview;
+    MovieReview **reviewdblptr = &reviewptr;
+    std::cout << "put a break point here for testing double pointers" << "\n";
+  }
 
   return 0;
 }

--- a/lmi-structs-classes.cc
+++ b/lmi-structs-classes.cc
@@ -15,7 +15,7 @@ class MovieReview {
     void printMovieRating() {
       std::cout << this->mov->title << ": " << this->rating << "/5" << "\n";
     }
-    
+
     MovieReview(movie *m, std::string review, int rating) {
       this->mov = m;
       this->review = review;
@@ -38,7 +38,8 @@ int main() {
     movie **dblptr = &ptr;
     MovieReview *reviewptr = &stargateReview;
     MovieReview **reviewdblptr = &reviewptr;
-    std::cout << "put a break point here for testing double pointers" << "\n";
+    std::cout << "ptr: "<< ptr << ", dblptr: " << dblptr << "\n";
+    std::cout << "reviewptr: "<< reviewptr << ", reviewdblptr: " << reviewdblptr << "\n";
   }
 
   return 0;

--- a/lmi-structs.cc
+++ b/lmi-structs.cc
@@ -11,9 +11,14 @@ void printMovie(movie &m) {
 }
 
 int main() {
-  movie amovie;
-  amovie.title = "Star Gate Continuum";
-  amovie.rating = 5;
-  printMovie(amovie);
+  movie stargate;
+  stargate.title = "Star Gate Continuum";
+  stargate.rating = 5;
+  printMovie(stargate);
+  
+  // Added for testing double pointers.
+  movie *ptr = &stargate;
+  movie **dblptr = &ptr;
+
   return 0;
 }

--- a/lmi-structs.cc
+++ b/lmi-structs.cc
@@ -3,22 +3,41 @@
 
 struct movie {
   std::string title;
-  int rating;
+  int year_released;
+  int budget;
 };
 
-void printMovie(movie &m) {
-  std::cout << m.title << ": " << m.rating << "\n";
-}
+class MovieReview {
+  public:
+    movie mov;
+    std::string review;
+    int rating;
+    void printMovieRating() {
+      std::cout << this->mov.title << ": " << this->rating << "/5" << "\n";
+    }
+    
+    MovieReview(movie m, std::string review, int rating) {
+      this->mov = m;
+      this->review = review;
+      this->rating = rating;
+    }
+};
 
 int main() {
   movie stargate;
   stargate.title = "Star Gate Continuum";
-  stargate.rating = 5;
-  printMovie(stargate);
+  stargate.year_released = 2008;
+  stargate.budget = 7000000;
+
+  MovieReview stargateReview(stargate, "The best thing since sliced bread.", 5);
+  stargateReview.printMovieRating();
   
   // Added for testing double pointers.
   movie *ptr = &stargate;
   movie **dblptr = &ptr;
+  MovieReview *reviewptr = &stargateReview;
+  MovieReview **reviewdblptr = &reviewptr;
+
 
   return 0;
 }


### PR DESCRIPTION
Previously, there weren't easily available examples for opening pointers in the memory inspector. This PR modifies some of the existing examples to include tests for inspecting
pointers and double pointers (pointer-to-pointer). 

This PR adds testing for pointers to primitives, structs, and classes. Since there were no examples for classes, this PR also added a class to `lmi-structs.cc` and renamed it `lmi-structs-classes.cc`. 